### PR TITLE
MainController#date_select_format? check params['timecop'] first 

### DIFF
--- a/app/controllers/timecop_console/main_controller.rb
+++ b/app/controllers/timecop_console/main_controller.rb
@@ -33,7 +33,7 @@ module TimecopConsole
 
       # http://api.rubyonrails.org/classes/ActionView/Helpers/DateHelper.html#method-i-date_select
       def date_select_format?
-        params['timecop']['current_time(1i)'].present?
+        params['timecop'].present? && params['timecop']['current_time(1i)'].present?
       end
   end
 end

--- a/spec/controllers/main_controller_spec.rb
+++ b/spec/controllers/main_controller_spec.rb
@@ -20,7 +20,19 @@ describe TimecopConsole::MainController do
       post :update, :timecop => timecop_param, :use_route => :timecop_console
 
       response.should redirect_to("where_i_came_from")
-    end 
+    end
+
+    context "with backward compatible format" do
+      let(:date_params) do
+        { year: 2013, month: 8, day: 22, hour: 12, min: 0, sec: 0 }
+      end
+
+      it 'redirects back' do
+        post :update, date_params.merge(use_route: :timecop_console)
+
+        response.should redirect_to("where_i_came_from")
+      end
+    end
   end
 
   describe "GET to :reset" do


### PR DESCRIPTION
I discovered that when you pass a date hash not using the timecop format to the update controller you get the following error:

NoMethodError: undefined method `[]' for nil:NilClass

Solution is to check first for the existence of params['timecop'] before getting into the nested hash.
